### PR TITLE
Fix query for new order_quotes table

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -200,7 +200,7 @@ FROM (
     GROUP BY uid
 ) AS t
 LEFT OUTER JOIN orders o ON o.uid = t.uid
-LEFT OUTER JOIN order_fee_parameters f ON f.order_uid = t.uid
+LEFT OUTER JOIN order_quotes f ON f.order_uid = t.uid
 ;";
     sqlx::query_as(query)
         .bind(settlement_block)


### PR DESCRIPTION
This PR just changes the analysis query to use the renamed `order_quotes` table introduced in https://github.com/cowprotocol/services/pull/295.

Note that the columns that it was using continue to exist with the same name, so no other changes were required.

### Test Plan

Double check this works once https://github.com/cowprotocol/services/pull/295 is merged.